### PR TITLE
fix: websocket endpoint error

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x, 15.x]
+        node-version: [16.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/lib/service_websocket.js
+++ b/lib/service_websocket.js
@@ -4,6 +4,7 @@ const qs = require('qs');
 const url = require('url');
 const http = require('http');
 const crypto = require('crypto');
+const path = require('path');
 const systemSign = require('hc-service-client/lib/signature/system_call');
 
 const utils = require('./utils');
@@ -40,6 +41,8 @@ module.exports = function (u, proxyHeaders) {
     let defaultQuery = u.defaultQuery instanceof Object ? u.defaultQuery : qs.parse(u.defaultQuery);
     let customerQuery = qs.parse(url.parse(clientReq.url).query);
     options.path = utils.mergeQuery(proxyUrl, defaultQuery, customerQuery);
+    options.url = path.join(u.endpoint, options.path);
+    options.path = url.parse(options.url).path;
 
     const sign = systemSign({
       accessKeyId: u.accessKeyId,

--- a/lib/websocket.js
+++ b/lib/websocket.js
@@ -2,6 +2,7 @@ const qs = require('qs');
 const url = require('url');
 const http = require('http');
 const crypto = require('crypto');
+const path = require('path');
 
 
 const utils = require('./utils');
@@ -36,6 +37,8 @@ module.exports = function (u, proxyHeaders) {
     let defaultQuery = u.defaultQuery instanceof Object ? u.defaultQuery : qs.parse(u.defaultQuery);
     let customerQuery = qs.parse(url.parse(clientReq.url).query);
     options.path = utils.mergeQuery(proxyUrl, defaultQuery, customerQuery);
+    options.url = path.join(u.endpoint, options.path);
+    options.path = url.parse(options.url).path;
 
     const proxyReq = http.request(options);
     proxyReq.on('error', (err) => {


### PR DESCRIPTION
solve the ws enpoint bug

```js
{
     endpoint: 'http://localhost:8081',
     api: ['/ws/*']
}
```
this work.terminal endpoint is http://localhost:8081/ws/*
```js
{
    endpoint: 'http://localhost:8081/ws',
    api: ['/*']
}
```
not work.